### PR TITLE
Provide an easy Renku deployment on GKE

### DIFF
--- a/gcloud-helm/Makefile
+++ b/gcloud-helm/Makefile
@@ -1,0 +1,28 @@
+.EXPORT_ALL_VARIABLES:
+ROK_PGP_FP=2E8E3E6447725A15025BD90E859123913F532F3E
+ANDREAS_PGP_FP=E05F8E490B6D5305E7D23051B880C4C4CDEB85CF
+PAMELA_PGP_FP=FE818AFB977D00CECC07E3A097253E0453A2EA8A
+SOPS_PGP_FP=${ROK_PGP_FP},${ANDREAS_PGP_FP},${PAMELA_PGP_FP}
+
+.PHONY: encrypt decrypt values clean
+
+default: decrypt values
+
+encrypt:
+	@echo 'Encrypting values for: ${SOPS_PGP_FP}'
+	@sops -e unsecured.yaml > secured.yaml
+	@echo 'Generated: secured.yaml'
+
+decrypt:
+	@echo 'Decrypting values'
+	@sops -d secured.yaml > unsecured.yaml
+	@echo 'Generated: unsecured.yaml'
+
+values:
+	@echo 'Preparing basic-renku-values.yaml and renkulab-gitlab.yaml'
+	@scripts/render-values.py --template basic-renku-values.tmpl --values unsecured.yaml --key credentials --output basic-renku-values.yaml
+	@scripts/render-values.py --template renkulab-gitlab.tmpl --values unsecured.yaml --key credentials --output renkulab-gitlab.yaml
+	@echo 'Generated basic-renku-values.yaml and renkulab-gitlab.yaml'
+
+clean:
+	@rm unsecured.yaml basic-renku-values.yaml renkulab-gitlab.yaml

--- a/gcloud-helm/README.md
+++ b/gcloud-helm/README.md
@@ -7,11 +7,12 @@ Note: Currently this deployment is done against renkulab/gitlab, this will be co
 
 * Have `kubectl`, `gcloud` and `helm` installed locally
 * Have a domain ready to be configured
-* Have a service account keyfile for the script to use
+* Have a service account with a JSON private key (script will use it), with the following roles: Compute Viewer (roles/compute.viewer), (Project) Viewer (roles/viewer), Kubernetes Engine Admin (roles/container.admin), Service Account User (roles/iam.serviceAccountUser).
 * Create an application on renkulab gitlab. Follow the instructions in [here](https://renku.readthedocs.io/en/latest/developer/example-configurations/renkulab.html), replace the <your-minikube-ip> bits with the domain and use https for the redirect URLs. Copy the application ID and secret and paste them in renkulab-gitlab.yaml
 
 ### Further configuration:
 
+* Replace the email in line 10 of helm-installs/cert-manager-issuer.yaml
 * If needed, replace the keyfile name in line 5 of the script
 * The cluster name and details can be changed at will
 * Make sure there's a `basic-renku-values.yaml` file, you can use `basic-renku-values.tmpl` and replace the secrets (delimited with brackets, e.g. `{global_gitlab_clientSecret}`) either using sops (see Makefile) or manually.

--- a/gcloud-helm/README.md
+++ b/gcloud-helm/README.md
@@ -1,0 +1,31 @@
+## Create a test deployment of Renku on GCP
+
+The  `create-renku-cluster-gcp.sh` is a script that will create a test cluster and deploy nginx-ingress, cert-manager and Renku using helm.
+Note: Currently this deployment is done against renkulab/gitlab, this will be configurable in the future.
+
+### Prerequisites:
+
+* Have `kubectl`, `gcloud` and `helm` installed locally
+* Have a domain ready to be configured
+* Have a service account keyfile for the script to use
+* Create an application on renkulab gitlab. Follow the instructions in [here](https://renku.readthedocs.io/en/latest/developer/example-configurations/renkulab.html), replace the <your-minikube-ip> bits with the domain and use https for the redirect URLs. Copy the application ID and secret and paste them in renkulab-gitlab.yaml
+
+### Further configuration:
+
+* If needed, replace the keyfile name in line 5 of the script
+* The cluster name and details can be changed at will
+* Make sure there's a `basic-renku-values.yaml` file, you can use `basic-renku-values.tmpl` and replace the secrets (delimited with brackets, e.g. `{global_gitlab_clientSecret}`) either using sops (see Makefile) or manually.
+
+### Deploy Renku in a test cluster
+
+Clone this repo, cd into this directory and run the script:
+
+```
+$ ./create-renku-cluster-gcp.sh
+```
+
+Right before deploying Renku the script will give you the IP to configure the domain name against and will ask for the domain.
+
+### Post-install configurations
+
+Configure the identity provider according to the [Configure the identity provider section](https://renku.readthedocs.io/en/latest/developer/example-configurations/renkulab.html).

--- a/gcloud-helm/basic-renku-values.tmpl
+++ b/gcloud-helm/basic-renku-values.tmpl
@@ -4,9 +4,13 @@
 
 ---
 variables_switchboard:
-  mainURL:                   &mainURL                       gcp-renku.get-renga.io
-  ingressTLS:                &ingressTLS                    gcp-renku-get-renga-io-tls
-  gitlabURL:                 &gitlabURL                     https://gcp-renku.get-renga.io/gitlab
+  mainURL:                   &mainURL                       [domain]
+  gitlabURL:                 &gitlabURL                     https://[domain]/gitlab
+  jupyterhubURL:             &jupyterhubURL                 https://[domain]/jupyterhub
+  gatewayURL:                &gatewayURL                    https://[domain]/api
+  jupyterhubAuthCallbackUrl: &jupyterhub_gitlab_callbackUrl https://[domain]/jupyterhub/hub/oauth_callback
+  oauth_redirect_uri:        &oauth_redirect_uri            https://[domain]/api/auth/jupyterhub/token
+  ingressTLS:                &ingressTLS                    [ingress-tls]
 
 ingress:
   enabled: true
@@ -31,7 +35,7 @@ global:
     clientSecret: {global_gateway_clientSecret}
     gitlabClientSecret: {global_gateway_gitlabClientSecret}
   renku:
-    version: 'latest'
+    domain: *mainURL
 
 keycloak:
   createDemoUser: true
@@ -53,6 +57,10 @@ gitlab:
   sharedRunnersRegistrationToken: {gitlab_sharedRunnersRegistrationToken}
   demoUserIsAdmin: true
 
+ui:
+  gatewayUrl: *gatewayURL
+  jupyterhubUrl: *jupyterhubURL
+
 notebooks:
   securityContext:
     enabled: false
@@ -72,6 +80,7 @@ notebooks:
           admin: true
           oauth_client_id: &gatewayClient gateway
           apiToken: &gatewaySecret {nb_jupyterhub_hub_services_gateway_apiToken}
+          oauth_redirect_uri: *oauth_redirect_uri
       extraEnv:
         - name: GITLAB_URL
           value: *gitlabURL
@@ -90,10 +99,9 @@ notebooks:
       state:
         enabled: true
         cryptoKey: {nb_jupyterhub_auth_state_cryptoKey}
-      type: gitlab
       gitlab:
-        clientId: jupyterhub
         clientSecret: {nb_jupyterhub_auth_gitlab_clientSecret}
+        callbackUrl: *jupyterhub_gitlab_callbackUrl
 
 runner:
   enabled: true

--- a/gcloud-helm/basic-renku-values.tmpl
+++ b/gcloud-helm/basic-renku-values.tmpl
@@ -1,0 +1,126 @@
+#
+# Configuration file for deploying the renku chart on GKE
+#
+
+---
+variables_switchboard:
+  mainURL:                   &mainURL                       gcp-renku.get-renga.io
+  ingressTLS:                &ingressTLS                    gcp-renku-get-renga-io-tls
+  gitlabURL:                 &gitlabURL                     https://gcp-renku.get-renga.io/gitlab
+
+ingress:
+  enabled: true
+  annotations:
+    kubernetes.io/ingress.class: 'nginx'
+    nginx.ingress.kubernetes.io/ssl-redirect: 'false'
+    nginx.ingress.kubernetes.io/proxy-body-size: '0' # Adjust to a reasonable value for production to avoid DOS attacks.
+    nginx.ingress.kubernetes.io/proxy-request-buffering: 'off' # Needed if GitLab is behind this ingress
+    cert-manager.io/cluster-issuer: letsencrypt-production
+  hosts:
+  - *mainURL
+  tls:
+  - hosts:
+    - *mainURL
+    secretName: *ingressTLS
+global:
+  useHTTPS: true
+  gitlab:
+    clientSecret: {global_gitlab_clientSecret}
+    urlPrefix: /gitlab
+  gateway:
+    clientSecret: {global_gateway_clientSecret}
+    gitlabClientSecret: {global_gateway_gitlabClientSecret}
+  renku:
+    version: 'latest'
+
+keycloak:
+  createDemoUser: true
+  keycloak:
+    username: admin
+
+
+gitlab:
+  oauth:
+    autoSignIn: true
+  ssh:
+    externalPort: 30022
+    nodePortService:
+      enabled: true
+      nodePort: 30022
+  registry:
+    enabled: true
+    exposedAs: NodePort
+  sharedRunnersRegistrationToken: {gitlab_sharedRunnersRegistrationToken}
+  demoUserIsAdmin: true
+
+notebooks:
+  securityContext:
+    enabled: false
+  jupyterhub:
+    rbac:
+      enabled: true
+    hub:
+      cookieSecret: {nb_jupyterhub_hub_cookieSecret}
+      baseUrl: '/jupyterhub/'
+      db:
+        type: postgres
+        url: postgres+psycopg2://jupyterhub@renku-postgresql:5432/jupyterhub
+      services:
+        notebooks:
+          apiToken: {nb_jupyterhub_hub_services_notebooks_apiToken}
+        gateway:
+          admin: true
+          oauth_client_id: &gatewayClient gateway
+          apiToken: &gatewaySecret {nb_jupyterhub_hub_services_gateway_apiToken}
+      extraEnv:
+        - name: GITLAB_URL
+          value: *gitlabURL
+        - name: DEBUG
+          value: "1"
+        - name: JUPYTERHUB_SPAWNER_CLASS
+          value: spawners.RenkuKubeSpawner
+        - name: PGPASSWORD
+          valueFrom:
+              secretKeyRef:
+                name: renku-jupyterhub-postgres
+                key: jupyterhub-postgres-password
+    proxy:
+      secretToken: {nb_jupyterhub_proxy_secretToken}
+    auth:
+      state:
+        enabled: true
+        cryptoKey: {nb_jupyterhub_auth_state_cryptoKey}
+      type: gitlab
+      gitlab:
+        clientId: jupyterhub
+        clientSecret: {nb_jupyterhub_auth_gitlab_clientSecret}
+
+runner:
+  enabled: true
+
+graph:
+  jena:
+    users:
+      admin:
+        password: {graph_jena_admin_password}
+      renku:
+        password: &sparql-password {graph_sparql_password}
+  gitlab:
+    url: *gitlabURL
+  webhookService:
+    hookToken:
+      secret: {graph_webhook_service_secret}
+  tokenRepository:
+    tokenEncryption:
+      secret: {graph_token_repository_secret}
+
+gateway:
+  development: true
+  secretKey: {gateway_secretKey}
+  jupyterhub:
+    clientId: *gatewayClient
+    clientSecret: *gatewaySecret
+  graph:
+    sparql:
+      username: admin
+      password: *sparql-password

--- a/gcloud-helm/create-renku-cluster-gcp.sh
+++ b/gcloud-helm/create-renku-cluster-gcp.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+
+#echo "Please make sure you ran: gcloud init --console-only"
+echo "*** Activating service account"
+gcloud auth activate-service-account  --key-file bash-optical-caldron-265813-23a530269ce6.json
+
+# create the cluster
+CLUSTER_NAME="renku-test"
+echo "*** Checking if cluster exists"
+CLUSTERS=`gcloud container clusters list`
+if [[ $CLUSTERS != *$CLUSTER_NAME* ]]; then
+  echo "*** Creating cluster, this will take a while..."
+  gcloud container clusters create $CLUSTER_NAME --project "optical-caldron-265813" \
+   --cluster-version "1.15.7-gke.23" --zone "europe-west4-a" --machine-type "n1-standard-2" \
+   --no-enable-autoupgrade --enable-autorepair --no-shielded-integrity-monitoring \
+    --num-nodes "2"
+   #--enable-autoscaling --min-nodes "1" --max-nodes "3"
+  sleep 10
+fi
+
+echo "*** Checking if helm is installed"
+CHECK=`helm version`
+if [[ $CHECK == *"Error: could not find tiller"* ]]; then
+  # deploy tiller
+  echo "*** Deploying tiller"
+  kubectl apply -f helm-installs/tiller-rbac-config.yaml
+  helm init --override 'spec.template.spec.containers[0].command'='{/tiller,--storage=secret,--listen=localhost:44134}' --service-account tiller --upgrade
+  CHECK=`helm version`
+  while [[ $CHECK == *"Error"* ]]; do
+    echo "*** Waiting for Tiller to be initialized"
+    sleep 5
+    CHECK=`helm version`
+  done
+  echo "*** Tiller initialized $CHECK"
+fi
+
+echo "*** Checking if letsencrypt is installed"
+CHECK=`helm list cert-manager`
+if [[ -z $CHECK ]]; then
+  # deploy letsencrypt
+  echo "*** Deploying letsencrypt"
+  kubectl apply -f https://raw.githubusercontent.com/jetstack/cert-manager/release-0.12/deploy/manifests/00-crds.yaml
+  #kubectl label namespace kube-system certmanager.k8s.io/disable-validation=true
+  kubectl create namespace cert-manager
+  helm repo add jetstack https://charts.jetstack.io
+  helm repo update
+  helm install --name cert-manager --namespace cert-manager jetstack/cert-manager  --version 0.12.0 -f helm-installs/cert-manager-values.yaml
+  sleep 10
+  echo "*** Creating a cluster issuer"
+  kubectl apply -f helm-installs/cert-manager-issuer.yaml
+  kubectl get clusterissuer.cert-manager.io
+fi
+
+echo "*** Checking if nginx-ingress is installed"
+CHECK=`helm list nginx-ingress`
+if [[ -z $CHECK ]]; then
+  # deploy nginx ingress
+  echo "*** Deploying nginx-ingress"
+  kubectl create namespace nginx-ingress
+  helm install --name nginx-ingress stable/nginx-ingress --namespace nginx-ingress --version 1.29.3 --set rbac.create=true --set controller.publishService.enabled=true
+  echo "*** Waiting for nginx-ingress to be initialized and an external IP to be assigned"
+  IP=`kubectl get service nginx-ingress-controller -n nginx-ingress | awk '{print $4}' | tail -1`
+  while [[ -z "$IP" ]]; do ## TODO THIS IS NOT WORKING
+    sleep 20
+    IP=`kubectl get service nginx-ingress-controller -n nginx-ingress | awk '{print $4}' | tail -1`
+  done
+else
+  IP=`kubectl get service nginx-ingress-controller -n nginx-ingress | awk '{print $4}' | tail -1`
+fi
+
+# get IP
+echo "*** IP to be used: ${IP}. Please asociate this IP to your domain and enter the domain name (example.com): "
+read -ep 'Domain: ' DOMAIN
+
+#DOMAIN=${IP}
+#DOMAIN="gcp-renku.get-renga.io"
+#INGRESSTLS="gcp-renku-get-renga-io-tls"
+
+INGRESSTLS=`echo $DOMAIN | tr . -`
+echo "*** Going to use $DOMAIN for Renku configuration and $INGRESSTLS for the Renku ingress."
+
+# deploy renku
+echo "*** Deploying Renku"
+cp basic-renku-values.yaml renku-values.yaml
+sed -i "s/\[domain\]/$DOMAIN/g" renku-values.yaml
+sed -i "s/\[ingress-tls\]/$INGRESSTLS/g" renku-values.yaml
+
+helm upgrade --install  renku renku/renku --namespace renku --version 0.5.2 \
+ -f renku-values.yaml -f renkulab-gitlab.yaml \
+ --timeout 1800 --cleanup-on-fail
+
+echo "*** Congrats! Renku is deployed. To get the keycloak admin password run: kubectl get secrets -n renku keycloak-password-secret -ojsonpath=\"{.data.keycloak-password}\" | base64 --decode"
+exit
+
+# old complete command used
+helm upgrade --install  renku renku/renku --namespace renku --version 0.5.2 \
+  -f basic-renku-values.yaml -f renkulab-gitlab.yaml \
+  --set global.renku.domain="${DOMAIN}"  \
+  --set ui.jupyterhubUrl=https://${DOMAIN}/jupyterhub --set ui.gatewayUrl=https://${DOMAIN}/api  \
+  --set gateway.keycloakUrl=https://${DOMAIN} \
+  --set notebooks.jupyterhub.hub.services.gateway.oauth_redirect_uri=https://${DOMAIN}/api/auth/jupyterhub/token  \
+  --set notebooks.jupyterhub.auth.gitlab.callbackUrl=https://${DOMAIN}/jupyterhub/hub/oauth_callback \
+  --timeout 1800 --cleanup-on-fail

--- a/gcloud-helm/helm-installs/cert-manager-issuer.yaml
+++ b/gcloud-helm/helm-installs/cert-manager-issuer.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: cert-manager.io/v1alpha2
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-production
+spec:
+  acme:
+    server: https://acme-v02.api.letsencrypt.org/directory
+    # Fill in the admin email for the domain names
+    email: pamela.delgado@epfl.ch ## TO UPDATE ##
+    privateKeySecretRef:
+      name: letsencrypt-production
+    solvers:
+    - http01:
+        ingress:
+          class: nginx

--- a/gcloud-helm/helm-installs/cert-manager-values.yaml
+++ b/gcloud-helm/helm-installs/cert-manager-values.yaml
@@ -1,0 +1,5 @@
+createCustomResource: true
+ingressShim:
+  enabled: false
+rbac:
+  enabled: true

--- a/gcloud-helm/helm-installs/nginx-values.yaml
+++ b/gcloud-helm/helm-installs/nginx-values.yaml
@@ -1,0 +1,13 @@
+controller:
+  nodeSelector:
+    ingress-node: "true"
+  kind: DaemonSet
+  service:
+    type: NodePort
+    nodePorts:
+      http: 32080
+      https: 32443
+rbac:
+  create: true
+tcp:
+  "32022": renku/renku-gitlab:22

--- a/gcloud-helm/helm-installs/tiller-rbac-config.yaml
+++ b/gcloud-helm/helm-installs/tiller-rbac-config.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tiller
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: tiller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: tiller
+    namespace: kube-system

--- a/gcloud-helm/renkulab-gitlab.tmpl
+++ b/gcloud-helm/renkulab-gitlab.tmpl
@@ -9,9 +9,6 @@ variables:
   # gcp-renku
   gitlabClientId:     &gitlabClientId      {gitlab_client_id}
   gitlabClientSecret: &gitlabClientSecret  {gitlab_client_secret}
-  # rancher-gcp
-  #gitlabClientId:     &gitlabClientId      51e347963bd22e3c9d15d62c5053283262dcb2a111e456b3f47cfa33560f11ca
-  #gitlabClientSecret: &gitlabClientSecret  d4474838294e192b26f89e64d7448b74dd65961cf9cd18574090c352601ec4b0
   gitlabRegistryHost: &gitlabRegistryHost  registry.renkulab.io
 
 gitlab:

--- a/gcloud-helm/renkulab-gitlab.tmpl
+++ b/gcloud-helm/renkulab-gitlab.tmpl
@@ -1,0 +1,49 @@
+# Configuration file for deploying the renku chart on minikube
+# against the gitlab of another Renku deployment. We also need to configure the keycloak instance which is part
+# of Renku to use Renku deployment as identity provider. See the developer docs
+# (https://renku.readthedocs.io/en/latest/developer/example-configurations/renkulab.html)
+# for instructions on how to use this values file.
+
+variables:
+  gitlabURL:          &renkuGitlabURL      https://renkulab.io/gitlab
+  # gcp-renku
+  gitlabClientId:     &gitlabClientId      {gitlab_client_id}
+  gitlabClientSecret: &gitlabClientSecret  {gitlab_client_secret}
+  # rancher-gcp
+  #gitlabClientId:     &gitlabClientId      51e347963bd22e3c9d15d62c5053283262dcb2a111e456b3f47cfa33560f11ca
+  #gitlabClientSecret: &gitlabClientSecret  d4474838294e192b26f89e64d7448b74dd65961cf9cd18574090c352601ec4b0
+  gitlabRegistryHost: &gitlabRegistryHost  registry.renkulab.io
+
+gitlab:
+  enabled: false
+
+notebooks:
+  gitlab:
+    url: *renkuGitlabURL
+    registry:
+      host: *gitlabRegistryHost
+  jupyterhub:
+    hub:
+      extraEnv:
+        - name: GITLAB_URL
+          value: *renkuGitlabURL
+        - name: JUPYTERHUB_SPAWNER_CLASS
+          value: spawners.RenkuKubeSpawner
+        - name: PGPASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: renku-jupyterhub-postgres
+              key: jupyterhub-postgres-password
+    auth:
+      gitlab:
+        clientId: *gitlabClientId
+        clientSecret: *gitlabClientSecret
+
+graph:
+  gitlab:
+    url: *renkuGitlabURL
+
+gateway:
+  gitlabUrl: *renkuGitlabURL
+  gitlabClientId: *gitlabClientId
+  gitlabClientSecret: *gitlabClientSecret

--- a/gcloud-helm/scripts/render-values.py
+++ b/gcloud-helm/scripts/render-values.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright 2017-2019 - Swiss Data Science Center (SDSC)
+# A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+# Eidgenössische Technische Hochschule Zürich (ETHZ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Render file for given template and values."""
+
+# TODO: Look into streamlining it with dev-values.py
+
+import argparse
+import os
+import subprocess
+import base64
+from ruamel.yaml import YAML
+
+yaml = YAML()
+
+# Avoid mangling of quotes.
+yaml.preserve_quotes = True
+
+def main():
+    """Run dev deploy."""
+    argparser = argparse.ArgumentParser(description=__doc__)
+
+    argparser.add_argument(
+        '--template',
+        help='Template file.')
+    argparser.add_argument(
+        '--values',
+        help='Values file.')
+    argparser.add_argument(
+        '--key',
+        help='Render only values under specific key.'
+    )
+    argparser.add_argument(
+        '--output',
+        help='Output filename.'
+    )
+    args = argparser.parse_args()
+
+    if args.template is None and args.values is None:
+        raise RuntimeError(
+            'You must specify a template and values to render.'
+        )
+
+    with open(args.template) as tmpl:
+        template_ = tmpl.read()
+    with open(args.values) as values:
+        values_ = yaml.load(values.read())
+        if args.key:
+            values_ = values_[args.key]
+        renku_values = template_.format(**values_)
+    with open(args.output, 'w') as output:
+        output.write(renku_values)
+
+
+if __name__ == '__main__':
+    main()

--- a/gcloud-helm/secured.yaml
+++ b/gcloud-helm/secured.yaml
@@ -1,0 +1,103 @@
+credentials:
+    global_gitlab_clientSecret: ENC[AES256_GCM,data:GboqBJ6ARxgq0VcyiwM1YZ0rCzEgSBiuMMEcgc2K2eoDlZEf,iv:2FOwxG1zS9sQLGIBkQRRaGQ+9AVBd2OwEj4fymAEX24=,tag:9UZU4KgzY6Z3VxSPW8cGIQ==,type:str]
+    global_gateway_clientSecret: ENC[AES256_GCM,data:GIR6BYpjxsmfgTnc9DAGmMc9bsBLbq8lDhDRKdQ6mK/bgfc6,iv:eN7hPtrroZQqtMrz5FUeyiaIH1ubEpmZIS6kBObG2NE=,tag:HBG51eENjZJJr+v5Au+bzg==,type:str]
+    global_gateway_gitlabClientSecret: ENC[AES256_GCM,data:iermmCfZ+sOzpsibXt9B3rdv2kPexHHdK209psrdSEMQgGmZBrFmamHf2KPyU0vlhviysZTDXXqIXw+aFz93rA==,iv:KRreIbq8IlcBjl4Yn8CJOQ8XYn3K6JcoZsnJ2PSBJPY=,tag:+GGO5BVET6fO+1pDWda/GA==,type:str]
+    #ENC[AES256_GCM,data:eZetYdPzAWU=,iv:dhdDzTM2yr4Ir5en7JIzJxHPJ6bRxZrbOHaUpn4WNP8=,tag:Nyjl17ZyaGbZ7usXAqrVFw==,type:comment]
+    #ENC[AES256_GCM,data:/OPrgOPmysC8Y4mWP1ECDg==,iv:2pn12GVHlvF9CzjNWnj4cklllpK7vG72JKGLcAb5Y4E=,tag:Oqef3dj56JdiQp1dSNAeDQ==,type:comment]
+    gitlab_sharedRunnersRegistrationToken: ENC[AES256_GCM,data:FKv6YTnQufgntIoJW9u1+xlIIahaGRnKvninbYvAhowwvaRaKStBaIWZ46iIsKqTzWy/TDivnnkbzZlCKVexJA==,iv:Qmxm5mBgjGdSF8GtTot2ORwjZgtWDgVGwZXBwS/dQBM=,tag:gAJ4LrfO3soN6dDaQc6ZGQ==,type:str]
+    #ENC[AES256_GCM,data:ZU/DLEwqruTkriPSftWz7HvAtSsk93HeUYpi,iv:0zwc+lElOYocYa2O6jCp3evIRmwRDSv7LKsW6QbpKXw=,tag:R4toL8gZufdLz9RRH2IcAQ==,type:comment]
+    #ENC[AES256_GCM,data:GNUcSMicQmDWYg==,iv:4eH4rZ6xV5LgmcOUM1Que90RpU55+pXG+Dt2YbBwZPo=,tag:tn04KOOYEh6KNMG6NhsI4A==,type:comment]
+    #ENC[AES256_GCM,data:PGzufzu69ZjEc0V1SYstxY5w,iv:vzDDjNblBzoJpVNn8xYXe1t8AzmObexjuuDIwBZuAtI=,tag:j9LD6e8z2ZmNAQ7WpjrIyA==,type:comment]
+    #ENC[AES256_GCM,data:F+eDbyUDZkN/CSU=,iv:l9qpL9stu6fzolGxaCau1AygLluC6edQQ21+QxywSAw=,tag:ljPfJo6A7SHfEgnMtItgVQ==,type:comment]
+    nb_jupyterhub_hub_cookieSecret: ENC[AES256_GCM,data:v39YBtEIFp+jD8DM/JcjdsE2sXWK0sS1ZjPbpmm4MuNCd4gOlCjVBxskW/KViNFj7kF6ml/yJUM/roAx+4hIBQ==,iv:Zi9sHABjZfIur+iwS0rKyMFQP3in/wWv0suMJE19cvg=,tag:NPPglMv9j+hLOdE8Q80DVw==,type:str]
+    nb_jupyterhub_hub_services_notebooks_apiToken: ENC[AES256_GCM,data:rAUp9Op1CbuCQYKD+ig=,iv:bJloHic1OeIZST5s69jFvM6pvaAEi/7YE8f64TTfJyo=,tag:A1VvVCPx5fGRREZSKSN9+g==,type:str]
+    nb_jupyterhub_hub_services_gateway_apiToken: ENC[AES256_GCM,data:LbW3mYsvUmUteSQOBxjnpRgRCdkVslPVmAaYBFZO7k8FLZWlPUlQRyHKOjJ/uBx9G3jc7oIam7JN39FhU894Hg==,iv:S53JLUd5q26EARGTuDNzU3JD6Z6J3d+camrNllSJbaU=,tag:W6UNpMGx3DfX+TCJmv6KiQ==,type:str]
+    nb_jupyterhub_proxy_secretToken: ENC[AES256_GCM,data:KkA/jJFZf6VEf1Y5mWj/GodAOMgrnboSO2hST33yVLyZI/1ywfdo/65krEWChNtNJyKY+R9Uz6Rvv2hIZ/MkrQ==,iv:byDaRf0JxlL5CLaTtpGZzBnTVOF4bf3J/VkbWfEQ6ec=,tag:KivxuSLLsq5dzrLUxzMqMA==,type:str]
+    nb_jupyterhub_auth_state_cryptoKey: ENC[AES256_GCM,data:3JkzDsyU0ZeIzMgjmehPlKjNRlVL1K6znz5GG9wNDjaYLkr7EkrmRqQZdaAwaa95+Z6sdAosKJ9YYAz0DqDxtQ==,iv:Y5vOSaZo24w5lVZM8QjLCs5jaypeJeyi5Dq4V9e1j5A=,tag:ONnFMuqSreVgMZ6Nj72dsQ==,type:str]
+    nb_jupyterhub_auth_gitlab_clientSecret: ENC[AES256_GCM,data:9FebBID9y/oOjPVC,iv:DogVhqywM4bPq1Kl4BbhvGCbRiHPqAX9r8SeL5WrtBE=,tag:iicF6bIl0qcFU2nWPfxAoQ==,type:str]
+    #ENC[AES256_GCM,data:Aq9PsYE4z93k,iv:yfYarcvZ/annUMcZTnQ9Rz5egzMOd0uD9Jfa9sgplr0=,tag:Jx6wKpcQP+pEJ9TvPhLmlw==,type:comment]
+    gateway_secretKey: ENC[AES256_GCM,data:OeD7cIU1bMj4+P8gUPVerAfgqcBLE44YToqReLDuVgK6rAhwZS8bmqPIB6x4Izq33fBtG5sr/p7CIRLAq7VdUQ==,iv:kox1JcTbayT/b9HFA49klUX+vO/b5jXsmmWtfwD441M=,tag:UQA6UDy3ZZFeqEa9IbTH8g==,type:str]
+    #ENC[AES256_GCM,data:ewgXK/7SZQ==,iv:5wfZKLTx/lhHb7KW8yIh+iegRzHkeKo4idz5PwS2ljw=,tag:C9F+lQ7T2gHcXO3+K1VWgA==,type:comment]
+    graph_jena_admin_password: ENC[AES256_GCM,data:XUVL1JymPyDEFLEW3jmidA==,iv:pv2UNJ7n/oWFLG43UMUV2K4zSDdpGRkGvqMDt8hbuKo=,tag:zePlnb/HtWF39m5png1/HQ==,type:str]
+    graph_sparql_password: ENC[AES256_GCM,data:O0X+oHTNaxfnnQR+irvFazkbCxAQqkOXr44WWYFQkwM=,iv:rQz3PNUOmQobty0NMiwhW+laCekOX7QMuQRCTjju/i0=,tag:Dp4MZuK7KsuWVRsogWOEjA==,type:str]
+    graph_webhook_service_secret: ENC[AES256_GCM,data:+fqdOUEfRxMFMWtlJ96xNv9Zwc/RnUer,iv:uznAtmes9RMitvXK8Y3LO1NSlawQa8yGUfQI2G/uhwA=,tag:mf2VsddnlPre2sBfbm9rZA==,type:str]
+    graph_token_repository_secret: ENC[AES256_GCM,data:r/IxA//FQmumeKvWdZVNS8rzHvMWsk7v,iv:I4TcHFRWLg0Yp5phxc1roZjEyO1wWESqSRN9+6DtGC4=,tag:QlsAJRw4jcYtuxrgJjrnzA==,type:str]
+    #ENC[AES256_GCM,data:epwOL3VrXwA9iTsivcdLGos=,iv:krVI8PcO6JUnQUiQVhy3yi0KE6ZI7jpmtdLDdetdH/o=,tag:kNISrDAHFST1ZSuA8bJ+WA==,type:comment]
+    gitlab_client_id: ENC[AES256_GCM,data:o1e1pdZ0cKlDDxyAZnkMYb0KYHBLhUGs9ebu58Bcb2MkYDeKEWVjxMSrXt36tEjhrNM6gMmwSeDhpFTIXqjBVw==,iv:MkwOl4H795HfQqGaRyChsin6HbzDynYlAmQjWoJrTeI=,tag:RQfbUg/nU0e/A0AEaqgsrw==,type:str]
+    gitlab_client_secret: ENC[AES256_GCM,data:0u9DrL3GKafK0qbOTzMrQa5r2o3rCwYmeOwEybEKQwhy1k6bMhiIsKntPstiJE8E2yj4xmVIJzeuAfeEc0Vcjg==,iv:NTZ+PmUt+xbgyht54lIN4QyDVCERv0Oc7Kl4ZB2RS3Y=,tag:b63lkf9roDtcub4xtyRwDw==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    lastmodified: '2020-01-31T13:59:16Z'
+    mac: ENC[AES256_GCM,data:8MV1MBSjukREAbkRmzNZSEFv6iCbf6nb2fJ1dAJ85fQf9bv+6Oh/YiqKYZ5G1nYoGKst7rFslXG9wufr5KXtNYZWXcnMApCNAcDQQaVKWKo468zWwGt/nNZEIXW9WGcGwHpwI47wS4MVkUKuk/pmD+yD+Z8amUCAbFb7PdZjJVw=,iv:P1T4p3owAmBvBSDRHH7yu9OCzXQrdOI54btHc4/V44U=,tag:QpwwBr5x0aWB3Fx4MQhHlg==,type:str]
+    pgp:
+    -   created_at: '2020-01-31T13:59:15Z'
+        enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            wcFMA/gW1/UTu4b7ARAAWVh1IOp6zBYbNPe7K8WNLliUoWcO+rhbazc2Wgg4ckn2
+            kc0vS5+vX8BV1nIf7Qq0hci3lzZa2dOA5Obg5EfoOh+vQLUJLMQPsBguJmlLMK0f
+            JGq+Mq5Fkcu3SJ8R2BroUnX0kM0TRG1hkrrlpqZaKswLVgc5dPMU1wsNjcifskfC
+            MGGYDDbUdvAtWRjwf+DPyQOXWS0coNR3dIuudiUnV2yKN3D5DQBFSMqhEgO0Itd6
+            m28cdwgMDsFO1U2meqJIa/KMgVAbBqjSGeJefAIN7xP1LTOySWin1OaWH9cI3W93
+            IXyftB70w3ZietC/40Lc16XH+IqFdm6bbf7UGUIrpqLjivCj0zAKCV6QaG0rzF2A
+            8LiKY30JN5nbIW/T0cdZw1H29Hk5gUkI8HYdTKfm1EQOTPGk9+FTBqWR0A3XLPW8
+            69vQC0NbKUt1rwPOZ6YpKKBOjCYltHdgyG/WGWfWuTLkv7tLhb6s/dL6IgtfCyIb
+            e8SJU4Be8XXJtS5RDWInkkO1NN1FCPS3715X/pHu5/Ns5zpM3906JT1IfBym37rX
+            rFTBQ/9qLf+6fgFw49i06RpX1zYHO31K0ZWchZ+VbElU8U//qOJiSA8xTCOujoFH
+            r/gJL8XRrsVbsWU5j+x127Q/yMC41/OQzlUv18W2qwGe/x0jA4KFIZd3fhtTHT7S
+            4AHkyjkwP2sw2qfGKwKDa+cJNuFTaeBA4Lvh6CTgsOKoLSkW4PvlCbZHm9IaNBvY
+            A8+9vpzrN4CTh3IVEw6SK+wVbpFGy9DgAeRKjrdMfNLJJpWg/3chqJ4A4mhc0ebh
+            mowA
+            =HRZ3
+            -----END PGP MESSAGE-----
+        fp: 2E8E3E6447725A15025BD90E859123913F532F3E
+    -   created_at: '2020-01-31T13:59:15Z'
+        enc: |
+            -----BEGIN PGP MESSAGE-----
+
+            hQIMA8WCAhDhl37NAQ//Tit60e4thUZsvyuvJAUkAjRoShtMq3/Nx2HsCpRVEAaw
+            srXGCK53M33A2zGx9PtNY1taDUAJ1lrY2gaglaTRGU7L4O6aX9Pbtaynbr5ySn3E
+            yefXYruWTf92Kn9GvPK/N22pN8klYZ4b7VKpQRxaIYXgqOfZWLWrMu2NjCrZZNgM
+            qZu8gjouqCRXh5t4fqMKZyAlsVcap0fZodVXX2Ne7uDArU/VGhMw+HofVj09rjit
+            VOpdhxY3/pJ2qKYZqlVHd/Lw62/j6eZrJVS/0NkrnLnBvQ8Ah3TKLZFlUev/2g/w
+            U7sfhK1NejBa4X7aW3njxioUtFeUo9RqPRX/GgMuWVgM0WNJwR0Jz3bRDTaGIqir
+            om1LepdJqzJWJsOGqbg5e3dFiYJLyY8E1HKqcfLAytix1iYfjuXlunYCdzvr4Aut
+            XdAWsHHDi/wnQk0XiOwjPcgVsNLK/1ypIqjdROI2smQEDpVdJ18N93/PDCQA3iW4
+            vvoRBrNXHAa/ZFV0bnl5okNZBlmDz5kdJM17+OCQRU940agsIWA4rKEWhYAGTtkN
+            wU7YpYGapHFD0BeSTSIg8bM8adVwH+BncreBFFIL1mDSoQNZ/lzRcg7I9Y/a7xg7
+            EJ822QecpdFz/rWghgvz5KL4Dc40ZZNPVc3A9qRCMb8/+5nRIWSZtB+hATfYCPbS
+            XAHmfIEDGTNLKRVRR78NznebBN7dHeyP/EKdH6OFTQZE7lCZNjuYeQCOzEBmFbU+
+            vepoqsoX8/VUFsB5x4O0nmo1214U0FzAhGPq3dYK81DlhXXZ4Gr+RwvN7IOO
+            =nYsR
+            -----END PGP MESSAGE-----
+        fp: E05F8E490B6D5305E7D23051B880C4C4CDEB85CF
+    -   created_at: '2020-01-31T13:59:15Z'
+        enc: |
+            -----BEGIN PGP MESSAGE-----
+
+            hQMOA1NvD/hfciYWEAv8DS6+GKFZpapqStgN0z7Frt+ICV9stt5neeDKh4XdBj7N
+            6QFgHF8//+pNbeW59Yepsxbg9/ORga9w4QBy+jTXtV1p4ZrCerrbkrDpsHC8LxS1
+            NwqiRErvEXXJeGEAzy0woracGN1kmkR4WKot/7hADIC+kN9XoOSpcz94qaHZXGmO
+            EXDz0u62kV5JrsKnmUjnzisvrH1OjFz00JAw2RXK5z7XVKCHq+N3JX7YM0aO/Fyc
+            tLaIm1Z1tOq9aajAcF7w19npH3UuXJ1oL6Dme0k3V7md6PCRIPFATbJ4pXaIELA/
+            N3tncgbng05hH9duo/Koi68uVc5oAm/9atONvj9bvsi8nTKBF5DS3Ki1g+I1tSWF
+            Ud9k3roBPTQFFPtyYC78xMH7EzhLjH1zPRoCynlGcQq07Fh6kEkaZAidsANzmtDL
+            4JzCUJzN5tynB2VLSPVNhbCfBlGJS7HDHPd96GLiVLahz2Mi6+mbUCIrxeYq8w3N
+            ishXD06lloGD5Wq0doF/C/43DKfKn69AMCoHgThzLW68Lr0tF/8UTu8Kp6ilXoDz
+            8uBWRXHHenUSzRY4NJlErEQ/pqt/ggn5kYgLCHV5n6Kby97mQK3zTJ7XPgS8VRnO
+            e2wBPU7C7RgFT3Vo2zA6l45KAZ55hlyrtWT1VfFsfSgs5oaTI5z3oBNc904Li1eN
+            id1aYU+unHPve+UfWM4VrxISs8lDgJELWyfBU0rOkfK3LmJmaZQvYtoO6QnjBDB1
+            A/4mkB6EOCZ4QYHa8lZ726a9vd26bXNWe0tPQGhFbFNDzFiyB/0g2q74svhs5Wai
+            MV9SRG+qkYpV52T9nxpQmOGt5rRgofc5UmGnixLPLLLj6/aR2cu1hoYJlj1DKz0d
+            3xiKCf6sdEYGzM2HN/NcOA9M/DYcEIEk016KmZtQXP4htl9YFTaVwANjDUvw/glR
+            wySdUgpPQ7dot9M9aKffe9e0HiFPg2GOWOE4DZ8lA36W5IuJ30V53fdMua/K3PKr
+            Zk8E+2aqYLulQ602tuWW1IHSXAH3Mss/Hz8cs761f/KR+QYJCHqgkGHrdPmH5x+F
+            GIzjQKYIN9S8UqgMdKb3gtaq/2w4bGclvYmCCoypIAcFWTVTsBrDgSokx2zW+RxJ
+            7fJUUiQW5GXJTwZJ8JV6
+            =XiT4
+            -----END PGP MESSAGE-----
+        fp: FE818AFB977D00CECC07E3A097253E0453A2EA8A
+    unencrypted_suffix: _unencrypted
+    version: 3.3.0


### PR DESCRIPTION
Initially this branch was supposed to document and version the files and commands used for the deployment of Renku on GKE. Please see #16 description.
Since the clusters are rebuilt and to ensure deployment reproducibility I made a script that creates a cluster, and deploys nginx-ingress, lets-encrypt and Renku (see README for usage).
The files here could be used for creating a general test Renku cluster. The idea is that any user with a GCP account can clone the repo, create a service account and just run the script to get a working Renku deployment against renkulab/gitlab.
With that goal in mind, we could probably get rid of the sops encryption altogether and just generate random passwords for when the script is used.